### PR TITLE
fix: mousemove handler uses global `event` instead of arrow function parameter `e`

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -576,8 +576,8 @@ export const init = (
   document.addEventListener("mousemove", (e) => {
     const centerX = window.innerWidth / 2
     const centerY = window.innerHeight / 2
-    const mouseX = event.clientX
-    const mouseY = event.clientY
+    const mouseX = e.clientX
+    const mouseY = e.clientY
 
     const deltaX = mouseX - centerX
     const deltaY = mouseY - centerY


### PR DESCRIPTION
In src/Utils.js line 576, the mousemove listener declares parameter e
but reads event.clientX / event.clientY — relying on the non-standard 
global window.event instead.

This causes:
- TypeError: Cannot read properties of undefined (reading 'clientX')
  in environments where window.event is unavailable
- mousem shader uniform stuck at vec2(0.0, 0.0) — mouse distortion broken
- Naturally fails in Firefox < 66 and strict module contexts

Fix :-
// Before
const mouseX = event.clientX
const mouseY = event.clientY

// After  
const mouseX = e.clientX
const mouseY = e.clientY